### PR TITLE
fix(security): Add auth checks to checks.ts query functions

### DIFF
--- a/convex/__tests__/monitoring.test.ts
+++ b/convex/__tests__/monitoring.test.ts
@@ -256,7 +256,9 @@ describe("recordCheck", () => {
       checkedAt: now,
     });
 
-    const checks = await t.query(api.checks.getRecentForMonitor, { monitorId });
+    const checks = await t
+      .withIdentity(user)
+      .query(api.checks.getRecentForMonitor, { monitorId });
     expect(checks).toHaveLength(1);
     expect(checks[0]).toMatchObject({
       monitorId,
@@ -279,7 +281,9 @@ describe("recordCheck", () => {
       checkedAt: now,
     });
 
-    const checks = await t.query(api.checks.getRecentForMonitor, { monitorId });
+    const checks = await t
+      .withIdentity(user)
+      .query(api.checks.getRecentForMonitor, { monitorId });
     expect(checks[0].errorMessage).toBe("Connection timeout");
     expect(checks[0].status).toBe("down");
   });

--- a/convex/checks.ts
+++ b/convex/checks.ts
@@ -16,6 +16,16 @@ export const getRecentForMonitor = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthorized");
+    }
+
+    const monitor = await ctx.db.get(args.monitorId);
+    if (!monitor || monitor.userId !== identity.subject) {
+      throw new Error("Monitor not found");
+    }
+
     const limit = args.limit || 50;
 
     return await ctx.db
@@ -32,6 +42,16 @@ export const getUptimeStats = query({
     days: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthorized");
+    }
+
+    const monitor = await ctx.db.get(args.monitorId);
+    if (!monitor || monitor.userId !== identity.subject) {
+      throw new Error("Monitor not found");
+    }
+
     const days = args.days || 30;
     const startTime = Date.now() - days * 24 * 60 * 60 * 1000;
 
@@ -161,6 +181,16 @@ export const getDailyStatus = query({
     }),
   ),
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthorized");
+    }
+
+    const monitor = await ctx.db.get(args.monitorId);
+    if (!monitor || monitor.userId !== identity.subject) {
+      throw new Error("Monitor not found");
+    }
+
     const days = args.days ?? 30;
     const startTime = Date.now() - days * 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

- Add authentication and ownership verification to `getRecentForMonitor`, `getUptimeStats`, and `getDailyStatus` queries
- These queries previously allowed unauthenticated access to private monitor data (response times, uptime stats, daily status)
- Return generic "Monitor not found" for both non-existent and wrong-owner monitors to prevent enumeration attacks

## Changes

- `convex/checks.ts`: Add auth + ownership checks to 3 query functions
- `convex/__tests__/checks.test.ts`: Add auth tests, update existing tests to use authenticated context
- `convex/__tests__/monitoring.test.ts`: Update to use authenticated queries

## Test plan

- [x] All 415 existing tests pass
- [x] New tests verify unauthorized access is rejected
- [x] New tests verify wrong-user access is rejected
- [x] Type-check passes
- [x] Lint passes

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monitoring queries now require user authentication and validate ownership of monitor data, ensuring users can only access their own monitoring information.

* **Tests**
  * Extended test coverage to include authenticated access verification and unauthorized access scenarios across all monitoring queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->