### PR TITLE
fix(a11y): Add Escape key handler to MonitorSettingsModal

### DIFF
--- a/components/MonitorSettingsModal.tsx
+++ b/components/MonitorSettingsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, FormEvent } from "react";
+import { useState, FormEvent, useEffect } from "react";
 import { useMutation } from "convex/react";
 import { api } from "../convex/_generated/api";
 import { Id } from "../convex/_generated/dataModel";
@@ -50,6 +50,14 @@ export function MonitorSettingsModal({
   });
 
   const [errors, setErrors] = useState<ValidationErrors>({});
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [onClose]);
 
   const validateForm = (): boolean => {
     const result = validateMonitorForm({


### PR DESCRIPTION
## Summary

- Add Escape key handler to MonitorSettingsModal for keyboard accessibility
- Users can now press Escape to close the modal (in addition to clicking backdrop or X button)

## Test plan

- [ ] Open a monitor settings modal
- [ ] Press Escape key - modal should close
- [ ] Verify backdrop click still works
- [ ] Verify X button still works

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Monitor Settings modal can now be dismissed by pressing the Escape key, enhancing keyboard accessibility and user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->