### PR TITLE
fix(ux): Surface specific error messages on monitor creation

### DIFF
--- a/components/AddMonitorForm.tsx
+++ b/components/AddMonitorForm.tsx
@@ -61,7 +61,11 @@ export function AddMonitorForm({ onSuccess }: { onSuccess?: () => void }) {
       }
     } catch (err) {
       console.error("Failed to create monitor:", err);
-      setError("Failed to create monitor. Please try again.");
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Failed to create monitor. Please try again.";
+      setError(message);
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## Summary
Display backend error messages to users instead of generic "Failed to create monitor" message.

## Before
When SSRF validation blocked a URL like `http://localhost:3000`:
```
Failed to create monitor. Please try again.
```

## After
```
URL cannot target internal networks (e.g., localhost, 127.0.0.1)
```

## Test plan
- [x] Type-check passes
- [x] All 889 tests pass
- [ ] Manually test creating monitor with invalid URL (e.g., internal IP)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when adding a monitor: failures now surface more specific error messages so users see clearer reasons for issues, aiding troubleshooting. No changes to success behavior or UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->