### PR TITLE
docs: Add Convex cleanup and Promise.allSettled conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,11 +125,20 @@ await ctx.runMutation(internal.deleteItems, { ids: batch.map((b) => b._id) });
 Use `Promise.allSettled` (not `Promise.all`) for ISR/SSR pages with multiple data sources. This enables graceful degradation — show partial data rather than full error page.
 
 ```typescript
-// ✅ Graceful degradation
+// ✅ Graceful degradation with error logging
 const [statsResult, checksResult] = await Promise.allSettled([
   fetchStats(),
   fetchChecks(),
 ]);
+
+// Log failures for debugging while still rendering partial data
+if (statsResult.status === "rejected") {
+  console.error("Failed to fetch stats:", statsResult.reason);
+}
+if (checksResult.status === "rejected") {
+  console.error("Failed to fetch checks:", checksResult.reason);
+}
+
 const stats =
   statsResult.status === "fulfilled" ? statsResult.value : defaultStats;
 const checks = checksResult.status === "fulfilled" ? checksResult.value : [];


### PR DESCRIPTION
## Summary
Codify patterns learned from PR review feedback on #83 and #84.

### Conventions Added

**Convex Cleanup Jobs**
- Always paginate cleanup with `.take(N)` in a loop until no documents remain
- Single-batch cleanup leaves backlog at scale

**Public Page Data Fetching**
- Use `Promise.allSettled` for ISR/SSR pages with multiple data sources
- Enables graceful degradation — show partial data rather than full error

## Source
- PR #83: Codex + Gemini flagged incomplete cleanup pagination
- PR #84: Gemini suggested allSettled for resilience

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for cleanup jobs that handle paginated results to ensure reliable, repeated processing of large result sets.
  * Added recommendations for fetching multiple public-page data sources using patterns that enable graceful degradation instead of failing the whole page.
  * Documentation-only changes; no runtime or API behavior was altered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->