### PR TITLE
fix(security): add SSRF protection to webhook URL validation

### DIFF
--- a/convex/userSettings.ts
+++ b/convex/userSettings.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { query, mutation, internalQuery } from "./_generated/server";
+import { isInternalHostname } from "./lib/urlValidation";
 
 /**
  * Get user settings, creating defaults if none exist.
@@ -115,6 +116,10 @@ export const update = mutation({
       }
       if (url.protocol !== "https:") {
         throw new Error("Webhook URL must use HTTPS");
+      }
+      // SSRF protection: block internal network addresses
+      if (isInternalHostname(url.hostname)) {
+        throw new Error("Webhook URL cannot target internal networks");
       }
     }
 


### PR DESCRIPTION
## Summary
Addresses issue #32: Webhook URL missing SSRF protection.

## Problem
Webhook URL validation in `convex/userSettings.ts` only checked for HTTPS protocol. No blocklist for internal networks.

## Attack Vector
User sets `webhookUrl` to `https://169.254.169.254/...` or `https://internal-service.corp/` and triggers incident notifications to probe internal infrastructure.

## Solution
Reuse existing `isInternalHostname()` from `./lib/urlValidation.ts` (same check used by monitor URL validation).

```typescript
if (isInternalHostname(url.hostname)) {
  throw new Error("Webhook URL cannot target internal networks");
}
```

## Testing
- Existing tests for `isInternalHostname` cover all RFC 1918, localhost, link-local, and .local/.internal patterns

Closes #32

---
*Overnight builder: security hardening while you sleep* 🛡️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent webhook URLs from targeting internal networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->