### PR TITLE
fix(status): Handle unavailable uptime stats gracefully

### DIFF
--- a/app/status/[statusSlug]/page.tsx
+++ b/app/status/[statusSlug]/page.tsx
@@ -82,9 +82,7 @@ export default async function IndividualStatusPage({
 
   // Extract values with sensible defaults for failed queries
   const uptimeStats =
-    uptimeStatsResult.status === "fulfilled"
-      ? uptimeStatsResult.value
-      : { uptimePercentage: 100, totalChecks: 0 };
+    uptimeStatsResult.status === "fulfilled" ? uptimeStatsResult.value : null;
   const recentChecks =
     recentChecksResult.status === "fulfilled" ? recentChecksResult.value : [];
   const incidentsResponse =
@@ -121,7 +119,7 @@ export default async function IndividualStatusPage({
       theme={effectiveTheme}
       monitorName={monitor.name}
       status={monitor.status}
-      uptimePercentage={uptimeStats.uptimePercentage}
+      uptimePercentage={uptimeStats?.uptimePercentage ?? null}
       avgResponseTime={avgResponseTime}
       lastCheckAt={monitor.lastCheckAt}
       chartData={chartData}

--- a/components/GlassStatusPage.tsx
+++ b/components/GlassStatusPage.tsx
@@ -39,7 +39,7 @@ interface Incident {
 interface GlassStatusPageProps {
   monitorName: string;
   status: MonitorStatus;
-  uptimePercentage: number;
+  uptimePercentage: number | null;
   avgResponseTime: number;
   totalChecks?: number;
   lastCheckAt?: number;
@@ -177,13 +177,21 @@ export function GlassStatusPage({
             <p
               className={cn(
                 "text-5xl sm:text-6xl font-mono font-medium tracking-tight",
-                config.text,
+                uptimePercentage === null
+                  ? "text-[var(--color-text-muted)]"
+                  : config.text,
               )}
             >
-              {uptimePercentage.toFixed(2)}
-              <span className="text-[0.4em] text-[var(--color-text-muted)] ml-1">
-                %
-              </span>
+              {uptimePercentage === null ? (
+                "—"
+              ) : (
+                <>
+                  {uptimePercentage.toFixed(2)}
+                  <span className="text-[0.4em] text-[var(--color-text-muted)] ml-1">
+                    %
+                  </span>
+                </>
+              )}
             </p>
 
             {/* Uptime bar */}

--- a/components/StatusPageDetails.tsx
+++ b/components/StatusPageDetails.tsx
@@ -29,7 +29,7 @@ interface Incident {
 interface StatusPageDetailsProps {
   status: MonitorStatus;
   chartData: ChartDataPoint[];
-  uptimePercentage: number;
+  uptimePercentage: number | null;
   avgResponseTime: number;
   lastCheckAt?: number;
   incidents: Incident[];
@@ -62,7 +62,13 @@ export function StatusPageDetails({
 }: StatusPageDetailsProps) {
   // Determine stat card status colors
   const uptimeStatus =
-    uptimePercentage > 99 ? "good" : uptimePercentage > 95 ? "warn" : "bad";
+    uptimePercentage === null
+      ? undefined
+      : uptimePercentage > 99
+        ? "good"
+        : uptimePercentage > 95
+          ? "warn"
+          : "bad";
   const responseStatus =
     avgResponseTime < 200 ? "good" : avgResponseTime < 500 ? "warn" : "bad";
 
@@ -98,7 +104,11 @@ export function StatusPageDetails({
           {/* Featured Uptime Card - spans 2 columns */}
           <StatCard
             label="Uptime"
-            value={`${uptimePercentage.toFixed(1)}%`}
+            value={
+              uptimePercentage === null
+                ? "Unavailable"
+                : `${uptimePercentage.toFixed(1)}%`
+            }
             status={uptimeStatus}
             size="large"
             className="col-span-2"

--- a/components/themes/BlueprintStatusPage.tsx
+++ b/components/themes/BlueprintStatusPage.tsx
@@ -40,8 +40,10 @@ const formatDate = (timestamp?: number) => {
   return new Date(timestamp).toISOString().slice(0, 10);
 };
 
-const uptimeTone = (uptime: number): StatusKey =>
-  uptime >= 99 ? "up" : uptime >= 95 ? "degraded" : "down";
+const uptimeTone = (uptime: number | null): StatusKey => {
+  if (uptime === null) return "degraded";
+  return uptime >= 99 ? "up" : uptime >= 95 ? "degraded" : "down";
+};
 
 const responseTone = (ms: number): StatusKey =>
   ms <= 300 ? "up" : ms <= 800 ? "degraded" : "down";
@@ -74,8 +76,12 @@ export function BlueprintStatusPage({
   const metrics = [
     {
       tag: "DIM A",
-      value: `${uptimePercentage.toFixed(2)}%`,
-      detail: "Uptime ratio — nominal",
+      value:
+        uptimePercentage === null ? "—" : `${uptimePercentage.toFixed(2)}%`,
+      detail:
+        uptimePercentage === null
+          ? "Uptime ratio — unavailable"
+          : "Uptime ratio — nominal",
       tone: uptimeTone(uptimePercentage),
     },
     {
@@ -108,7 +114,10 @@ export function BlueprintStatusPage({
       id: "01",
       component: `${monitorName} Core`,
       status: uptimeTone(uptimePercentage),
-      spec: `${uptimePercentage.toFixed(2)}% uptime`,
+      spec:
+        uptimePercentage === null
+          ? "Uptime unavailable"
+          : `${uptimePercentage.toFixed(2)}% uptime`,
     },
     {
       id: "02",
@@ -188,7 +197,13 @@ export function BlueprintStatusPage({
               },
               { label: "Last Check", value: lastCheckLabel },
               { label: "Status", value: statusStyles[status].label },
-              { label: "Uptime", value: `${uptimePercentage.toFixed(2)}%` },
+              {
+                label: "Uptime",
+                value:
+                  uptimePercentage === null
+                    ? "—"
+                    : `${uptimePercentage.toFixed(2)}%`,
+              },
             ].map((item) => (
               <div key={item.label} className="flex flex-col gap-1">
                 <span className="text-[10px] uppercase tracking-[0.2em] text-white/50">
@@ -361,7 +376,7 @@ export function BlueprintStatusPage({
                 <div className="text-[10px] uppercase tracking-[0.2em] text-white/50">
                   Description
                 </div>
-                <div>{`Status ${statusStyles[status].label.toLowerCase()} — ${uptimePercentage.toFixed(2)}% uptime`}</div>
+                <div>{`Status ${statusStyles[status].label.toLowerCase()} — ${uptimePercentage === null ? "unavailable" : `${uptimePercentage.toFixed(2)}% uptime`}`}</div>
               </div>
               <div className="min-w-[120px]">
                 <div className="text-[10px] uppercase tracking-[0.2em] text-white/50">

--- a/components/themes/BroadsheetStatusPage.tsx
+++ b/components/themes/BroadsheetStatusPage.tsx
@@ -135,7 +135,9 @@ export function BroadsheetStatusPage({
                 </span>{" "}
                 with a thirty-day uptime holding steady at{" "}
                 <span className="font-semibold">
-                  {uptimePercentage.toFixed(2)}%
+                  {uptimePercentage === null
+                    ? "unavailable"
+                    : `${uptimePercentage.toFixed(2)}%`}
                 </span>
                 . Total checks logged: {totalChecksValue.toLocaleString()}.
               </p>
@@ -160,8 +162,14 @@ export function BroadsheetStatusPage({
               {[
                 {
                   label: "Uptime",
-                  value: `${uptimePercentage.toFixed(2)}%`,
-                  tone: "text-[#1e3a5f]",
+                  value:
+                    uptimePercentage === null
+                      ? "—"
+                      : `${uptimePercentage.toFixed(2)}%`,
+                  tone:
+                    uptimePercentage === null
+                      ? "text-[#6b6b6b]"
+                      : "text-[#1e3a5f]",
                 },
                 {
                   label: "Response",

--- a/components/themes/MemphisStatusPage.tsx
+++ b/components/themes/MemphisStatusPage.tsx
@@ -59,7 +59,8 @@ export function MemphisStatusPage({
     },
     {
       label: "Uptime (30d)",
-      status: `${uptimePercentage.toFixed(2)}%`,
+      status:
+        uptimePercentage === null ? "—" : `${uptimePercentage.toFixed(2)}%`,
       color: "text-[#a855f7]",
       dot: "bg-[#00d4ff]",
     },
@@ -145,7 +146,10 @@ export function MemphisStatusPage({
             },
             {
               label: "Uptime",
-              value: `${uptimePercentage.toFixed(2)}%`,
+              value:
+                uptimePercentage === null
+                  ? "—"
+                  : `${uptimePercentage.toFixed(2)}%`,
               icon: "%",
               valueColor: "text-[#a855f7]",
               accent: "bg-[#00d4ff]",

--- a/components/themes/MissionControlStatusPage.tsx
+++ b/components/themes/MissionControlStatusPage.tsx
@@ -40,8 +40,10 @@ const formatCountdown = (timestamp: number | undefined, now: number) => {
   return `T-MINUS 00:${minutes}:${seconds}`;
 };
 
-const uptimeTone = (uptime: number): StatusKey =>
-  uptime >= 99 ? "up" : uptime >= 95 ? "degraded" : "down";
+const uptimeTone = (uptime: number | null): StatusKey => {
+  if (uptime === null) return "degraded";
+  return uptime >= 99 ? "up" : uptime >= 95 ? "degraded" : "down";
+};
 
 const responseTone = (ms: number): StatusKey =>
   ms <= 250 ? "up" : ms <= 800 ? "degraded" : "down";
@@ -93,8 +95,8 @@ export function MissionControlStatusPage({
     },
     {
       label: "Uptime Ratio",
-      value: uptimePercentage.toFixed(2),
-      unit: "%",
+      value: uptimePercentage === null ? "—" : uptimePercentage.toFixed(2),
+      unit: uptimePercentage === null ? "" : "%",
       tone: uptimeTone(uptimePercentage),
     },
     {
@@ -121,7 +123,8 @@ export function MissionControlStatusPage({
     {
       name: monitorName,
       tone: status,
-      uptime: `${uptimePercentage.toFixed(2)}%`,
+      uptime:
+        uptimePercentage === null ? "—" : `${uptimePercentage.toFixed(2)}%`,
       latency: `${Math.round(avgResponseTime)}ms`,
     },
   ] satisfies Array<{

--- a/components/themes/SwissStatusPage.tsx
+++ b/components/themes/SwissStatusPage.tsx
@@ -101,7 +101,10 @@ export function SwissStatusPage({
               {[
                 {
                   label: "Uptime",
-                  value: `${uptimePercentage.toFixed(2)}%`,
+                  value:
+                    uptimePercentage === null
+                      ? "—"
+                      : `${uptimePercentage.toFixed(2)}%`,
                 },
                 {
                   label: "Response Time",

--- a/components/themes/UkiyoStatusPage.tsx
+++ b/components/themes/UkiyoStatusPage.tsx
@@ -150,8 +150,9 @@ export function UkiyoStatusPage({
           <section className="mb-6 grid gap-4 sm:grid-cols-3">
             {[
               {
-                value: uptimePercentage.toFixed(2),
-                unit: "%",
+                value:
+                  uptimePercentage === null ? "—" : uptimePercentage.toFixed(2),
+                unit: uptimePercentage === null ? "" : "%",
               },
               {
                 value: Math.round(avgResponseTime).toString(),

--- a/components/themes/types.ts
+++ b/components/themes/types.ts
@@ -21,7 +21,7 @@ export interface Incident {
 export interface StatusPageThemeProps {
   monitorName: string;
   status: MonitorStatus;
-  uptimePercentage: number;
+  uptimePercentage: number | null;
   avgResponseTime: number;
   totalChecks?: number;
   lastCheckAt?: number;


### PR DESCRIPTION
## Summary

Fixes #87 - When uptime stats query fails in status page, we now show "Unavailable" instead of misleading 100% uptime.

## Changes

### Data fetching
- Changed fallback from `{ uptimePercentage: 100, totalChecks: 0 }` to `null`

### Type system
- Updated `uptimePercentage` from `number` to `number | null`

### Components (all handle null gracefully)
- **GlassStatusPage**: Shows "—" with muted text
- **StatusPageDetails**: Shows "Unavailable" 
- **MissionControlStatusPage**: Shows "—"
- **BlueprintStatusPage**: Shows "—" + "Uptime unavailable"
- **SwissStatusPage**: Shows "—"
- **MemphisStatusPage**: Shows "—"
- **BroadsheetStatusPage**: Shows "—" with gray tone
- **UkiyoStatusPage**: Shows "—"

## Testing
✅ TypeCheck, lint, and all 889 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced status page display to gracefully handle missing uptime data across all themes. When uptime statistics are unavailable, status pages now show a clear placeholder indicator instead of incomplete values, with muted styling to visually distinguish the unavailable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->