### PR TITLE
test: add notification throttling tests

### DIFF
--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -234,6 +234,22 @@ export const markNotified = internalMutation({
 });
 
 /**
+ * Test helper to set notifiedAt to a specific timestamp.
+ * Used for testing throttling logic.
+ */
+export const testSetNotifiedAt = internalMutation({
+  args: {
+    incidentId: v.id("incidents"),
+    notifiedAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.incidentId, {
+      notifiedAt: args.notifiedAt,
+    });
+  },
+});
+
+/**
  * Send a test notification email.
  * Used to verify email setup is working.
  */


### PR DESCRIPTION
Closes #57

Adds comprehensive tests for the notification throttling logic in `sendIncidentNotification`.

## Test Coverage

- **Re-notification blocked within throttle window**: Verifies that a second "opened" notification is not sent when the throttle window hasn't expired
- **Notification allowed after throttle expires**: Confirms notifications are sent once the throttle window has passed
- **Throttling only applies to 'opened' notifications**: Ensures "resolved" notifications bypass the throttle check
- **First notification always allowed**: Validates that notifications are sent when `notifiedAt` is undefined
- **Custom throttle minutes respected**: Tests that user-configured throttle durations are honored

## Implementation Notes

- Added `vi.clearAllMocks()` in `beforeEach` to isolate test assertions from setup noise
- Tests use `testSetNotifiedAt` helper to simulate historical notification timestamps
- Mock timing controlled via `vi.advanceTimersByTime()` for deterministic test behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating notification throttling behavior, including: preventing duplicate notifications within a configurable time window, different handling for various notification statuses, and support for customizable throttle durations.
  * Added test helper to support notification testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->