### PR TITLE
fix: Harden Sentry and PostHog privacy defaults

### DIFF
--- a/lib/posthog/provider.tsx
+++ b/lib/posthog/provider.tsx
@@ -12,7 +12,9 @@ if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "/ingest",
     ui_host: "https://us.posthog.com",
+    person_profiles: "identified_only",
     capture_pageview: false,
+    respect_dnt: true,
     capture_pageleave: true,
     persistence: "localStorage",
     disable_session_recording: process.env.NODE_ENV !== "production",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -6,6 +6,7 @@ Sentry.init({
 
   // Performance monitoring
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  sendDefaultPii: false,
 
   // Session replay for visual debugging
   replaysSessionSampleRate: 0.1,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,4 +4,5 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  sendDefaultPii: false,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,6 +4,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  sendDefaultPii: false,
 
   // Redact sensitive data from server errors
   beforeSend(event) {


### PR DESCRIPTION
## Summary
Hardens observability configs with privacy-safe defaults across Sentry and PostHog.

## Changes
- **Sentry**: add `sendDefaultPii: false` to client, server, and edge configs
- **PostHog**: add `respect_dnt: true`, `person_profiles: "identified_only"`

## Test plan
- [ ] Verify Sentry still receives errors in staging
- [ ] Verify PostHog events still arrive
- [ ] Verify DNT header is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Analytics now respects Do Not Track preferences and tracks only identified users
* Error reporting no longer sends personally identifiable information with events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->