### PR TITLE
fix: Harden SSRF validation and redirect handling

### DIFF
--- a/convex/lib/urlValidation.ts
+++ b/convex/lib/urlValidation.ts
@@ -10,12 +10,27 @@ import {
   validateMonitorTargetUrl,
 } from "@/lib/domain/ssrf";
 
+export type UrlAllowance =
+  | { allowed: true }
+  | { allowed: false; reason: string };
+
 /**
- * Validate a URL is safe for server-side requests.
- * Returns error message or null if valid.
+ * Canonical SSRF gate for monitor targets.
+ */
+export function isAllowedUrl(url: string): UrlAllowance {
+  const reason = validateMonitorTargetUrl(url);
+  if (reason) {
+    return { allowed: false, reason };
+  }
+  return { allowed: true };
+}
+
+/**
+ * Backward-compatible validator that returns error string/null.
  */
 export function validateMonitorUrl(url: string): string | null {
-  return validateMonitorTargetUrl(url);
+  const result = isAllowedUrl(url);
+  return result.allowed ? null : result.reason;
 }
 
 export { isInternalHostname };

--- a/convex/monitors.ts
+++ b/convex/monitors.ts
@@ -5,7 +5,7 @@ import { toPublicMonitor } from "./publicTypes";
 import { computeStatus } from "../lib/domain/status";
 import { generateUniqueStatusSlug } from "./slugs";
 import { isPubliclyVisible } from "./lib/visibility";
-import { validateMonitorUrl } from "./lib/urlValidation";
+import { isAllowedUrl } from "./lib/urlValidation";
 import { hasActiveAccess } from "./subscriptions";
 
 const MIN_TIMEOUT_MS = 1000;
@@ -213,9 +213,9 @@ export const create = mutation({
     }
 
     // Validate URL to prevent SSRF attacks
-    const urlError = validateMonitorUrl(args.url);
-    if (urlError) {
-      throw new Error(urlError);
+    const urlValidation = isAllowedUrl(args.url);
+    if (!urlValidation.allowed) {
+      throw new Error(urlValidation.reason);
     }
 
     assertTimeoutInRange(args.timeout);
@@ -324,9 +324,9 @@ export const update = mutation({
 
     // Validate URL to prevent SSRF attacks (if URL is being updated)
     if (args.url) {
-      const urlError = validateMonitorUrl(args.url);
-      if (urlError) {
-        throw new Error(urlError);
+      const urlValidation = isAllowedUrl(args.url);
+      if (!urlValidation.allowed) {
+        throw new Error(urlValidation.reason);
       }
     }
 

--- a/lib/domain/__tests__/validation.test.ts
+++ b/lib/domain/__tests__/validation.test.ts
@@ -355,11 +355,15 @@ describe("isInternalHostname", () => {
 
   it("identifies internal IPv6 hostnames", () => {
     expect(isInternalHostname("[::1]")).toBe(true);
+    expect(isInternalHostname("::1")).toBe(true);
     expect(isInternalHostname("[::]")).toBe(true);
     expect(isInternalHostname("[fc00::1]")).toBe(true);
+    expect(isInternalHostname("fc00::1")).toBe(true);
     expect(isInternalHostname("[fe80::1]")).toBe(true);
+    expect(isInternalHostname("fe80::1")).toBe(true);
     expect(isInternalHostname("[ff02::1]")).toBe(true);
     expect(isInternalHostname("[::ffff:7f00:1]")).toBe(true);
+    expect(isInternalHostname("::ffff:7f00:1")).toBe(true);
     expect(isInternalHostname("[::ffff:c0a8:1]")).toBe(true);
   });
 
@@ -368,5 +372,11 @@ describe("isInternalHostname", () => {
     expect(isInternalHostname("api.github.com")).toBe(false);
     expect(isInternalHostname("8.8.8.8")).toBe(false);
     expect(isInternalHostname("[2001:4860:4860::8888]")).toBe(false);
+    expect(isInternalHostname("2001:4860:4860::8888")).toBe(false);
+  });
+
+  it("identifies decimal-encoded internal IPv4 hostnames", () => {
+    expect(isInternalHostname("2130706433")).toBe(true); // 127.0.0.1
+    expect(isInternalHostname("2852039166")).toBe(true); // 169.254.169.254
   });
 });

--- a/lib/domain/ssrf.ts
+++ b/lib/domain/ssrf.ts
@@ -13,26 +13,78 @@ const BLOCKED_HOSTNAME_PATTERNS: RegExp[] = [
   /^192\.168\.\d+\.\d+$/,
   /^169\.254\.\d+\.\d+$/, // AWS/cloud metadata
   /^0\.0\.0\.0$/,
-  /^\[::1\]$/i, // IPv6 loopback
-  /^\[::\]$/i, // IPv6 unspecified
-  /^\[fe[89ab][0-9a-f:.]*\]$/i, // IPv6 link-local (fe80::/10)
-  /^\[f[cd][0-9a-f:.]*\]$/i, // IPv6 unique local (fc00::/7)
-  /^\[::ffff:[0-9a-f:.]+\]$/i, // IPv4-mapped IPv6 (::ffff:0:0/96)
-  /^\[ff[0-9a-f:.]*\]$/i, // IPv6 multicast (ff00::/8)
   /\.local$/i,
   /\.internal$/i,
   /\.localhost$/i,
 ];
 
+const MAX_IPV4_DECIMAL = 0xffffffff;
+
 function normalizeHostname(hostname: string): string {
-  return hostname.replace(/\.+$/, "");
+  return hostname.trim().replace(/\.+$/, "").toLowerCase();
+}
+
+function stripIpv6Brackets(hostname: string): string {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
+function isInternalIpv6(hostname: string): boolean {
+  const normalized = stripIpv6Brackets(hostname);
+
+  return (
+    normalized === "::1" || // loopback
+    normalized === "::" || // unspecified
+    /^::ffff:/i.test(normalized) || // IPv4-mapped IPv6
+    /^(fc|fd)[0-9a-f]{2}:/i.test(normalized) || // unique local fc00::/7
+    /^fe[89ab][0-9a-f]:/i.test(normalized) || // link-local fe80::/10
+    /^ff[0-9a-f]{2}:/i.test(normalized) // multicast ff00::/8
+  );
+}
+
+function decodeDecimalIpv4(hostname: string): string | null {
+  if (!/^\d+$/.test(hostname)) {
+    return null;
+  }
+
+  const decimal = Number(hostname);
+  if (!Number.isInteger(decimal) || decimal < 0 || decimal > MAX_IPV4_DECIMAL) {
+    return null;
+  }
+
+  const a = (decimal >>> 24) & 0xff;
+  const b = (decimal >>> 16) & 0xff;
+  const c = (decimal >>> 8) & 0xff;
+  const d = decimal & 0xff;
+
+  return `${a}.${b}.${c}.${d}`;
 }
 
 export function isInternalHostname(hostname: string): boolean {
   const normalizedHostname = normalizeHostname(hostname);
-  return BLOCKED_HOSTNAME_PATTERNS.some((pattern) =>
-    pattern.test(normalizedHostname),
-  );
+
+  if (
+    BLOCKED_HOSTNAME_PATTERNS.some((pattern) =>
+      pattern.test(normalizedHostname),
+    )
+  ) {
+    return true;
+  }
+
+  if (isInternalIpv6(normalizedHostname)) {
+    return true;
+  }
+
+  const decodedIpv4 = decodeDecimalIpv4(normalizedHostname);
+  if (decodedIpv4) {
+    return BLOCKED_HOSTNAME_PATTERNS.some((pattern) =>
+      pattern.test(decodedIpv4),
+    );
+  }
+
+  return false;
 }
 
 export function validateMonitorTargetUrl(url: string): string | null {


### PR DESCRIPTION
## Summary
- hardened monitor URL SSRF validation to cover internal IPv6 patterns and decimal-encoded IPv4 hostnames
- introduced a canonical `isAllowedUrl()` contract and reused it in both mutation-time and runtime monitor validation paths
- switched monitor fetches to `redirect: "manual"` to prevent redirect-follow SSRF pivoting into internal networks
- expanded SSRF test coverage for IPv6 + decimal-encoding bypass vectors

## Behavior note
- Redirects are intentionally **not followed** for this fix, per issue scope and boundaries in #107.
- 3xx responses are treated as reachable responses ("up") unless a strict `expectedStatusCode` requires otherwise.

## Verification
- `bun test convex/lib/__tests__/urlValidation.test.ts lib/domain/__tests__/validation.test.ts`
- `bun lint`
- `bun type-check`
- pre-push hook: `bun test` (57 files / 970 tests passed)

## Risks / follow-ups
- IPv6 normalization can be further hardened with binary parsing for all equivalent textual forms.
- If product semantics should follow trusted redirects while preserving SSRF safety, implement bounded manual redirect hopping with per-hop validation in a follow-up issue.

Closes #107
