### PR TITLE
fix: make cleanupOldChecks honor tier retention

### DIFF
--- a/.groom/retro.md
+++ b/.groom/retro.md
@@ -5,5 +5,5 @@
 - predicted: effort/s
 - actual: effort/m
 - scope: added tier-aware retention in cleanup action + shared `historyDays` constant + retention tests
-- blocker: pre-push failed initially due pulse interval mismatch in new test; fixed by using tier-valid interval
+- blocker: pre-push failed initially due to pulse interval mismatch in new test; fixed by using tier-valid interval
 - pattern: retention rules tied to billing need shared server-side constants to avoid drift

--- a/.groom/retro.md
+++ b/.groom/retro.md
@@ -1,0 +1,9 @@
+# Delivery Retro Log
+
+## 2026-03-03 - Issue #108
+
+- predicted: effort/s
+- actual: effort/m
+- scope: added tier-aware retention in cleanup action + shared `historyDays` constant + retention tests
+- blocker: pre-push failed initially due pulse interval mismatch in new test; fixed by using tier-valid interval
+- pattern: retention rules tied to billing need shared server-side constants to avoid drift

--- a/convex/__tests__/monitoring.test.ts
+++ b/convex/__tests__/monitoring.test.ts
@@ -364,7 +364,7 @@ describe("cleanupOldChecks", () => {
         name: `${identity.subject} monitor`,
         url: "https://example.com",
         method: "GET",
-        interval: 60,
+        interval: subscription.tier === "pulse" ? 300 : 60,
         timeout: 10000,
         projectSlug: `${identity.subject}-project`,
       });

--- a/convex/__tests__/monitoring.test.ts
+++ b/convex/__tests__/monitoring.test.ts
@@ -455,4 +455,85 @@ describe("cleanupOldChecks", () => {
       .query(api.checks.getRecentForMonitor, { monitorId });
     expect(checks).toHaveLength(0);
   });
+
+  test("continues past non-deletable page to delete eligible pulse checks", async () => {
+    const t = setupBackend();
+    const vitalUser = {
+      name: "Vital User",
+      subject: "user_vital_paging",
+      issuer: "clerk",
+    };
+    const pulseUser = {
+      name: "Pulse User",
+      subject: "user_pulse_paging",
+      issuer: "clerk",
+    };
+
+    const vitalMonitorId = await createMonitorForUser(t, vitalUser, {
+      tier: "vital",
+    });
+    const pulseMonitorId = await createMonitorForUser(t, pulseUser, {
+      tier: "pulse",
+    });
+
+    const baseCheckedAt = Date.now() - 45 * dayMs;
+
+    // Fill the first cleanup page with non-deletable Vital checks.
+    for (let i = 0; i < 1001; i++) {
+      await t.mutation(internal.monitoring.recordCheck, {
+        monitorId: vitalMonitorId,
+        status: "up",
+        statusCode: 200,
+        responseTime: 120,
+        checkedAt: baseCheckedAt + i,
+      });
+    }
+
+    // Pulse check should still be deleted even if it is after the first page.
+    await t.mutation(internal.monitoring.recordCheck, {
+      monitorId: pulseMonitorId,
+      status: "up",
+      statusCode: 200,
+      responseTime: 130,
+      checkedAt: baseCheckedAt + 5_000,
+    });
+
+    await t.action(internal.monitoring.cleanupOldChecks, {});
+
+    const pulseChecks = await t
+      .withIdentity(pulseUser)
+      .query(api.checks.getRecentForMonitor, { monitorId: pulseMonitorId });
+    expect(pulseChecks).toHaveLength(0);
+  });
+
+  test("deletes orphaned checks when monitor was removed", async () => {
+    const t = setupBackend();
+    const pulseUser = {
+      name: "Pulse User",
+      subject: "user_orphan",
+      issuer: "clerk",
+    };
+    const monitorId = await createMonitorForUser(t, pulseUser, {
+      tier: "pulse",
+    });
+
+    await t.mutation(internal.monitoring.recordCheck, {
+      monitorId,
+      status: "up",
+      statusCode: 200,
+      responseTime: 100,
+      checkedAt: Date.now() - 45 * dayMs,
+    });
+
+    await t
+      .withIdentity(pulseUser)
+      .mutation(api.monitors.remove, { id: monitorId });
+    await t.action(internal.monitoring.cleanupOldChecks, {});
+
+    const oldChecks = await t.query(internal.monitoring.getOldChecks, {
+      beforeTimestamp: Date.now(),
+    });
+    const hasOrphan = oldChecks.some((check) => check.monitorId === monitorId);
+    expect(hasOrphan).toBe(false);
+  });
 });

--- a/convex/__tests__/monitoring.test.ts
+++ b/convex/__tests__/monitoring.test.ts
@@ -506,6 +506,65 @@ describe("cleanupOldChecks", () => {
     expect(pulseChecks).toHaveLength(0);
   });
 
+  test("resumes cleanup from provided cursor", async () => {
+    const t = setupBackend();
+    const vitalUser = {
+      name: "Vital User",
+      subject: "user_vital_resume",
+      issuer: "clerk",
+    };
+    const pulseUser = {
+      name: "Pulse User",
+      subject: "user_pulse_resume",
+      issuer: "clerk",
+    };
+
+    const vitalMonitorId = await createMonitorForUser(t, vitalUser, {
+      tier: "vital",
+    });
+    const pulseMonitorId = await createMonitorForUser(t, pulseUser, {
+      tier: "pulse",
+    });
+
+    const baseCheckedAt = Date.now() - 45 * dayMs;
+
+    for (let i = 0; i < 1001; i++) {
+      await t.mutation(internal.monitoring.recordCheck, {
+        monitorId: vitalMonitorId,
+        status: "up",
+        statusCode: 200,
+        responseTime: 120,
+        checkedAt: baseCheckedAt + i,
+      });
+    }
+
+    await t.mutation(internal.monitoring.recordCheck, {
+      monitorId: pulseMonitorId,
+      status: "up",
+      statusCode: 200,
+      responseTime: 130,
+      checkedAt: baseCheckedAt + 5_000,
+    });
+
+    const firstPage = await t.query(internal.monitoring.getOldChecksPage, {
+      beforeTimestamp: Date.now() - 30 * dayMs,
+      paginationOpts: {
+        numItems: 1000,
+        cursor: null,
+      },
+    });
+
+    expect(firstPage.isDone).toBe(false);
+    await t.action(internal.monitoring.cleanupOldChecks, {
+      cursor: firstPage.continueCursor,
+    });
+
+    const pulseChecks = await t
+      .withIdentity(pulseUser)
+      .query(api.checks.getRecentForMonitor, { monitorId: pulseMonitorId });
+    expect(pulseChecks).toHaveLength(0);
+  });
+
   test("deletes orphaned checks when monitor was removed", async () => {
     const t = setupBackend();
     const pulseUser = {

--- a/convex/__tests__/monitoring.test.ts
+++ b/convex/__tests__/monitoring.test.ts
@@ -341,3 +341,118 @@ describe("getDueMonitors", () => {
     expect(dueMonitors).toHaveLength(0);
   });
 });
+
+describe("cleanupOldChecks", () => {
+  const dayMs = 24 * 60 * 60 * 1000;
+
+  async function createMonitorForUser(
+    t: ReturnType<typeof setupBackend>,
+    identity: { name: string; subject: string; issuer: string },
+    subscription: {
+      tier: "pulse" | "vital";
+      status?: "trialing" | "active" | "past_due" | "canceled" | "expired";
+    },
+  ) {
+    await createTestSubscription(t, identity.subject, {
+      tier: subscription.tier,
+      status: subscription.status ?? "active",
+    });
+
+    const monitor = await t
+      .withIdentity(identity)
+      .mutation(api.monitors.create, {
+        name: `${identity.subject} monitor`,
+        url: "https://example.com",
+        method: "GET",
+        interval: 60,
+        timeout: 10000,
+        projectSlug: `${identity.subject}-project`,
+      });
+
+    return monitor!._id;
+  }
+
+  test("keeps 45-day checks for active Vital subscriptions", async () => {
+    const t = setupBackend();
+    const vitalUser = {
+      name: "Vital User",
+      subject: "user_vital",
+      issuer: "clerk",
+    };
+    const monitorId = await createMonitorForUser(t, vitalUser, {
+      tier: "vital",
+    });
+    const checkedAt = Date.now() - 45 * dayMs;
+
+    await t.mutation(internal.monitoring.recordCheck, {
+      monitorId,
+      status: "up",
+      statusCode: 200,
+      responseTime: 120,
+      checkedAt,
+    });
+
+    await t.action(internal.monitoring.cleanupOldChecks, {});
+
+    const checks = await t
+      .withIdentity(vitalUser)
+      .query(api.checks.getRecentForMonitor, { monitorId });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].checkedAt).toBe(checkedAt);
+  });
+
+  test("deletes 45-day checks for Pulse subscriptions", async () => {
+    const t = setupBackend();
+    const pulseUser = {
+      name: "Pulse User",
+      subject: "user_pulse",
+      issuer: "clerk",
+    };
+    const monitorId = await createMonitorForUser(t, pulseUser, {
+      tier: "pulse",
+    });
+
+    await t.mutation(internal.monitoring.recordCheck, {
+      monitorId,
+      status: "up",
+      statusCode: 200,
+      responseTime: 110,
+      checkedAt: Date.now() - 45 * dayMs,
+    });
+
+    await t.action(internal.monitoring.cleanupOldChecks, {});
+
+    const checks = await t
+      .withIdentity(pulseUser)
+      .query(api.checks.getRecentForMonitor, { monitorId });
+    expect(checks).toHaveLength(0);
+  });
+
+  test("defaults to Pulse retention for non-active subscriptions", async () => {
+    const t = setupBackend();
+    const trialUser = {
+      name: "Trial User",
+      subject: "user_trial",
+      issuer: "clerk",
+    };
+    const monitorId = await createMonitorForUser(t, trialUser, {
+      tier: "vital",
+      status: "trialing",
+    });
+
+    await t.mutation(internal.monitoring.recordCheck, {
+      monitorId,
+      status: "up",
+      statusCode: 200,
+      responseTime: 100,
+      checkedAt: Date.now() - 45 * dayMs,
+    });
+
+    await t.action(internal.monitoring.cleanupOldChecks, {});
+
+    const checks = await t
+      .withIdentity(trialUser)
+      .query(api.checks.getRecentForMonitor, { monitorId });
+    expect(checks).toHaveLength(0);
+  });
+});

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -1,8 +1,8 @@
 // Subscription tier limits - single source of truth
 // Used by both client (lib/tiers.ts) and server (subscriptions.ts)
 export const TIERS = {
-  pulse: { monitors: 15, minInterval: 180, statusPages: 1 },
-  vital: { monitors: 75, minInterval: 60, statusPages: 5 },
+  pulse: { monitors: 15, minInterval: 180, statusPages: 1, historyDays: 30 },
+  vital: { monitors: 75, minInterval: 60, statusPages: 5, historyDays: 90 },
 } as const;
 
 export type TierName = keyof typeof TIERS;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -11,6 +11,7 @@ crons.daily(
   "cleanup-old-checks",
   { hourUTC: 2, minuteUTC: 0 },
   internal.monitoring.cleanupOldChecks,
+  {},
 );
 
 // Cleanup old Stripe events daily at 3 AM UTC (idempotency tracking)

--- a/convex/monitoring.ts
+++ b/convex/monitoring.ts
@@ -1,3 +1,4 @@
+import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import {
   internalQuery,
@@ -5,6 +6,7 @@ import {
   internalAction,
 } from "./_generated/server";
 import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
 import { isAllowedUrl } from "./lib/urlValidation";
 import { INCIDENT_THRESHOLD } from "../lib/domain/status";
 import { TIERS } from "./constants";
@@ -407,16 +409,31 @@ export const cleanupOldChecks = internalAction({
 
     let totalDeleted = 0;
     let batchNumber = 0;
+    let cursor: string | null = null;
+    let reachedEnd = false;
 
     // Process up to maxBatchesPerRun batches, then reschedule if more remain
     while (batchNumber < maxBatchesPerRun) {
-      const oldChecks = await ctx.runQuery(internal.monitoring.getOldChecks, {
+      const oldChecksPage: {
+        page: Doc<"checks">[];
+        continueCursor: string;
+        isDone: boolean;
+      } = await ctx.runQuery(internal.monitoring.getOldChecksPage, {
         beforeTimestamp: pulseCutoffTimestamp,
+        paginationOpts: {
+          numItems: 1000,
+          cursor,
+        },
       });
+      const oldChecks = oldChecksPage.page;
+      cursor = oldChecksPage.continueCursor;
+      reachedEnd = oldChecksPage.isDone;
 
       if (oldChecks.length === 0) {
-        console.log(`[Cleanup] Complete: deleted ${totalDeleted} checks total`);
-        return;
+        if (reachedEnd) {
+          break;
+        }
+        continue;
       }
 
       batchNumber++;
@@ -424,39 +441,40 @@ export const cleanupOldChecks = internalAction({
       const monitorIds = Array.from(
         new Set(oldChecks.map((check) => check.monitorId)),
       );
-      const monitors = await ctx.runQuery(
+      const monitors = (await ctx.runQuery(
         internal.monitoring.getMonitorsByIds,
-        {
-          monitorIds,
-        },
-      );
+        { monitorIds },
+      )) as Doc<"monitors">[];
       const monitorsById = new Map(
         monitors.map((monitor) => [monitor._id, monitor]),
       );
 
-      const retentionDaysByUser = new Map<string, number>();
-      for (const monitor of monitors) {
-        if (retentionDaysByUser.has(monitor.userId)) {
-          continue;
-        }
-
-        const subscription = await ctx.runQuery(
-          internal.subscriptions.getByUserId,
-          {
-            userId: monitor.userId,
-          },
-        );
-        retentionDaysByUser.set(
-          monitor.userId,
-          getCheckRetentionDays(subscription),
-        );
-      }
+      const userIds = Array.from(
+        new Set(monitors.map((monitor) => monitor.userId)),
+      );
+      const subscriptionsByUser = (await ctx.runQuery(
+        internal.subscriptions.getByUserIds,
+        { userIds },
+      )) as Array<{
+        userId: string;
+        subscription: {
+          tier: "pulse" | "vital";
+          status: "trialing" | "active" | "past_due" | "canceled" | "expired";
+        } | null;
+      }>;
+      const retentionDaysByUser = new Map(
+        subscriptionsByUser.map((entry) => [
+          entry.userId,
+          getCheckRetentionDays(entry.subscription),
+        ]),
+      );
 
       const now = Date.now();
       const checksToDelete = oldChecks.filter((check) => {
         const monitor = monitorsById.get(check.monitorId);
         if (!monitor) {
-          return false;
+          // Monitor was removed; this check is orphaned and should be cleaned up.
+          return true;
         }
 
         const retentionDays =
@@ -470,10 +488,10 @@ export const cleanupOldChecks = internalAction({
       );
 
       if (checksToDelete.length === 0) {
-        console.log(
-          `[Cleanup] Complete: no checks eligible for deletion in current window (${totalDeleted} deleted total)`,
-        );
-        return;
+        if (reachedEnd) {
+          break;
+        }
+        continue;
       }
 
       // Delete in sub-batches to avoid mutation size limits
@@ -488,11 +506,34 @@ export const cleanupOldChecks = internalAction({
       totalDeleted += checksToDelete.length;
     }
 
+    if (reachedEnd) {
+      console.log(`[Cleanup] Complete: deleted ${totalDeleted} checks total`);
+      return;
+    }
+
     // More work remains - reschedule to continue
     await ctx.scheduler.runAfter(0, internal.monitoring.cleanupOldChecks, {});
     console.log(
       `[Cleanup] Paused after ${batchNumber} batches (${totalDeleted} deleted); rescheduled to continue`,
     );
+  },
+});
+
+/**
+ * Helper query to get old checks for cleanup with pagination.
+ */
+export const getOldChecksPage = internalQuery({
+  args: {
+    beforeTimestamp: v.number(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    return ctx.db
+      .query("checks")
+      .withIndex("by_checked_at", (q) =>
+        q.lt("checkedAt", args.beforeTimestamp),
+      )
+      .paginate(args.paginationOpts);
   },
 });
 

--- a/convex/monitoring.ts
+++ b/convex/monitoring.ts
@@ -7,6 +7,23 @@ import {
 import { internal } from "./_generated/api";
 import { isAllowedUrl } from "./lib/urlValidation";
 import { INCIDENT_THRESHOLD } from "../lib/domain/status";
+import { TIERS } from "./constants";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function getCheckRetentionDays(
+  subscription: {
+    tier: "pulse" | "vital";
+    status: "trialing" | "active" | "past_due" | "canceled" | "expired";
+  } | null,
+) {
+  // 90-day retention is reserved for actively paid Vital subscriptions.
+  if (subscription?.tier === "vital" && subscription.status === "active") {
+    return TIERS.vital.historyDays;
+  }
+
+  return TIERS.pulse.historyDays;
+}
 
 /**
  * Get monitors that are due for checking based on their interval.
@@ -383,10 +400,10 @@ export const runHeartbeat = internalAction({
 export const cleanupOldChecks = internalAction({
   args: {},
   handler: async (ctx) => {
-    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const pulseCutoffTimestamp = Date.now() - TIERS.pulse.historyDays * DAY_MS;
     const maxBatchesPerRun = 20; // Cap to stay well under 10-min timeout
 
-    console.log("[Cleanup] Starting cleanup of checks older than 30 days...");
+    console.log("[Cleanup] Starting tier-aware check cleanup...");
 
     let totalDeleted = 0;
     let batchNumber = 0;
@@ -394,7 +411,7 @@ export const cleanupOldChecks = internalAction({
     // Process up to maxBatchesPerRun batches, then reschedule if more remain
     while (batchNumber < maxBatchesPerRun) {
       const oldChecks = await ctx.runQuery(internal.monitoring.getOldChecks, {
-        beforeTimestamp: thirtyDaysAgo,
+        beforeTimestamp: pulseCutoffTimestamp,
       });
 
       if (oldChecks.length === 0) {
@@ -403,20 +420,72 @@ export const cleanupOldChecks = internalAction({
       }
 
       batchNumber++;
-      console.log(
-        `[Cleanup] Batch ${batchNumber}: deleting ${oldChecks.length} checks`,
+
+      const monitorIds = Array.from(
+        new Set(oldChecks.map((check) => check.monitorId)),
       );
+      const monitors = await ctx.runQuery(
+        internal.monitoring.getMonitorsByIds,
+        {
+          monitorIds,
+        },
+      );
+      const monitorsById = new Map(
+        monitors.map((monitor) => [monitor._id, monitor]),
+      );
+
+      const retentionDaysByUser = new Map<string, number>();
+      for (const monitor of monitors) {
+        if (retentionDaysByUser.has(monitor.userId)) {
+          continue;
+        }
+
+        const subscription = await ctx.runQuery(
+          internal.subscriptions.getByUserId,
+          {
+            userId: monitor.userId,
+          },
+        );
+        retentionDaysByUser.set(
+          monitor.userId,
+          getCheckRetentionDays(subscription),
+        );
+      }
+
+      const now = Date.now();
+      const checksToDelete = oldChecks.filter((check) => {
+        const monitor = monitorsById.get(check.monitorId);
+        if (!monitor) {
+          return false;
+        }
+
+        const retentionDays =
+          retentionDaysByUser.get(monitor.userId) ?? TIERS.pulse.historyDays;
+        const retentionCutoff = now - retentionDays * DAY_MS;
+        return check.checkedAt < retentionCutoff;
+      });
+
+      console.log(
+        `[Cleanup] Batch ${batchNumber}: deleting ${checksToDelete.length}/${oldChecks.length} eligible checks`,
+      );
+
+      if (checksToDelete.length === 0) {
+        console.log(
+          `[Cleanup] Complete: no checks eligible for deletion in current window (${totalDeleted} deleted total)`,
+        );
+        return;
+      }
 
       // Delete in sub-batches to avoid mutation size limits
       const deleteBatchSize = 100;
-      for (let i = 0; i < oldChecks.length; i += deleteBatchSize) {
-        const batch = oldChecks.slice(i, i + deleteBatchSize);
+      for (let i = 0; i < checksToDelete.length; i += deleteBatchSize) {
+        const batch = checksToDelete.slice(i, i + deleteBatchSize);
         await ctx.runMutation(internal.monitoring.deleteChecks, {
           checkIds: batch.map((c) => c._id),
         });
       }
 
-      totalDeleted += oldChecks.length;
+      totalDeleted += checksToDelete.length;
     }
 
     // More work remains - reschedule to continue
@@ -441,6 +510,20 @@ export const getOldChecks = internalQuery({
         q.lt("checkedAt", args.beforeTimestamp),
       )
       .take(1000);
+  },
+});
+
+export const getMonitorsByIds = internalQuery({
+  args: {
+    monitorIds: v.array(v.id("monitors")),
+  },
+  handler: async (ctx, args) => {
+    const monitors = await Promise.all(
+      args.monitorIds.map((monitorId) => ctx.db.get(monitorId)),
+    );
+    return monitors.filter(
+      (monitor): monitor is NonNullable<typeof monitor> => monitor !== null,
+    );
   },
 });
 

--- a/convex/monitoring.ts
+++ b/convex/monitoring.ts
@@ -400,8 +400,10 @@ export const runHeartbeat = internalAction({
  * more work remains.
  */
 export const cleanupOldChecks = internalAction({
-  args: {},
-  handler: async (ctx) => {
+  args: {
+    cursor: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args) => {
     const pulseCutoffTimestamp = Date.now() - TIERS.pulse.historyDays * DAY_MS;
     const maxBatchesPerRun = 20; // Cap to stay well under 10-min timeout
 
@@ -409,7 +411,7 @@ export const cleanupOldChecks = internalAction({
 
     let totalDeleted = 0;
     let batchNumber = 0;
-    let cursor: string | null = null;
+    let cursor: string | null = args.cursor ?? null;
     let reachedEnd = false;
 
     // Process up to maxBatchesPerRun batches, then reschedule if more remain
@@ -512,7 +514,9 @@ export const cleanupOldChecks = internalAction({
     }
 
     // More work remains - reschedule to continue
-    await ctx.scheduler.runAfter(0, internal.monitoring.cleanupOldChecks, {});
+    await ctx.scheduler.runAfter(0, internal.monitoring.cleanupOldChecks, {
+      cursor,
+    });
     console.log(
       `[Cleanup] Paused after ${batchNumber} batches (${totalDeleted} deleted); rescheduled to continue`,
     );

--- a/convex/subscriptions.ts
+++ b/convex/subscriptions.ts
@@ -227,6 +227,26 @@ export const getByUserId = internalQuery({
 });
 
 /**
+ * Internal query to get subscriptions by user IDs.
+ */
+export const getByUserIds = internalQuery({
+  args: { userIds: v.array(v.string()) },
+  handler: async (ctx, args) => {
+    const uniqueUserIds = Array.from(new Set(args.userIds));
+    const subscriptions = await Promise.all(
+      uniqueUserIds.map(async (userId) => ({
+        userId,
+        subscription: await ctx.db
+          .query("subscriptions")
+          .withIndex("by_user", (q) => q.eq("userId", userId))
+          .first(),
+      })),
+    );
+    return subscriptions;
+  },
+});
+
+/**
  * Create a subscription from Stripe webhook.
  * Internal only - called by convex/http.ts after signature verification.
  */

--- a/lib/tiers.ts
+++ b/lib/tiers.ts
@@ -10,7 +10,6 @@ const TIER_DETAILS = {
   pulse: {
     name: "Pulse",
     description: "Essential monitoring for side projects and small sites",
-    historyDays: 30,
     webhooks: false,
     apiAccess: false,
     monthlyPrice: 900, // cents
@@ -19,7 +18,6 @@ const TIER_DETAILS = {
   vital: {
     name: "Vital",
     description: "Professional monitoring for growing applications",
-    historyDays: 90,
     webhooks: true,
     apiAccess: true,
     monthlyPrice: 2900, // cents


### PR DESCRIPTION
## Summary
Fixes tier-blind retention in daily check cleanup so paid Vital history is no longer deleted at 30 days.

Closes #108.

## Changes
- Added `historyDays` to shared server/client tier limits in `convex/constants.ts`.
- Updated `convex/monitoring.ts::cleanupOldChecks` to:
  - fetch candidate checks older than Pulse threshold,
  - resolve monitor owner subscription tier/status,
  - delete only checks beyond the owner-specific retention window.
- Added `getMonitorsByIds` internal query to avoid per-check monitor lookups.
- Added cleanup retention tests in `convex/__tests__/monitoring.test.ts` for:
  - active Vital keeps 45-day checks,
  - Pulse deletes 45-day checks,
  - non-active subscriptions default to Pulse retention.
- Removed duplicated `historyDays` literals from `lib/tiers.ts` by relying on shared tier constants.

## Acceptance Criteria
- [x] Given a Vital user's monitor with checks from 45 days ago, cleanup does not delete them.
- [x] Given a Pulse user's monitor with checks from 45 days ago, cleanup deletes them.
- [x] Given a non-active subscription context, cleanup uses Pulse retention as default.
- [x] Cleanup keeps existing bounded batch loop behavior and processes candidates in batches.

## Manual QA
1. `bun lint`
2. `bun type-check`
3. `bunx vitest run convex/__tests__/monitoring.test.ts`
4. `git push -u origin fix/108-tier-aware-check-retention` (runs full pre-push test suite)
5. Expected:
- lint/type-check pass
- monitoring retention tests pass
- pre-push `vitest run` passes

## What Changed
```mermaid
graph TD
  A[cleanupOldChecks] --> B[get checks older than Pulse cutoff]
  B --> C[load check monitors]
  C --> D[load owner subscription]
  D --> E{active vital?}
  E -->|yes| F[retention = 90 days]
  E -->|no| G[retention = 30 days]
  F --> H[delete only checks older than monitor cutoff]
  G --> H
```

## Before / After
Before: cleanup deleted all checks older than 30 days, including Vital users who should retain 90 days.

After: cleanup applies retention per monitor owner (active Vital => 90 days, otherwise Pulse default 30 days), preserving paid history while still pruning old data.

## Test Coverage
- `convex/__tests__/monitoring.test.ts`
  - `cleanupOldChecks > keeps 45-day checks for active Vital subscriptions`
  - `cleanupOldChecks > deletes 45-day checks for Pulse subscriptions`
  - `cleanupOldChecks > defaults to Pulse retention for non-active subscriptions`
- Full repo tests executed by pre-push hook (`vitest run`): 58 files, 987 tests passing.

## Notes / Gaps
- Current fallback behavior for non-active subscription status is intentionally conservative (Pulse retention).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented tier-aware data retention policies: Vital subscriptions now retain monitoring data for 90 days, while Pulse subscriptions retain data for 30 days. Old checks are automatically cleaned up based on subscription tier.

* **Tests**
  * Added comprehensive test suite validating retention behavior across subscription tiers, including edge cases for active and non-active subscriptions.

* **Documentation**
  * Added delivery retro documenting implementation patterns and key learnings from this feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->