### PR TITLE
feat: scaffold API v1 conventions and OpenAPI contract

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Type Check
         run: bun type-check
 
+      - name: OpenAPI Lint
+        run: bun run lint:openapi
+
       - name: Validate Convex Schema (Production)
         if: env.CONVEX_DEPLOY_KEY != ''
         run: bunx convex deploy --dry-run

--- a/.groom/retro.md
+++ b/.groom/retro.md
@@ -7,3 +7,11 @@
 - scope: added tier-aware retention in cleanup action + shared `historyDays` constant + retention tests
 - blocker: pre-push failed initially due to pulse interval mismatch in new test; fixed by using tier-valid interval
 - pattern: retention rules tied to billing need shared server-side constants to avoid drift
+
+## 2026-03-03 - Issue #128 (Phase 0 via #129/#130)
+
+- predicted: effort/m
+- actual: effort/m
+- scope: added API conventions doc, OpenAPI v1 scaffold for planned endpoints, reusable contract helpers/tests, CI OpenAPI lint gate
+- blocker: OpenAPI 3.1 nullable semantics (`nullable`) failed lint; fixed via JSON Schema union/null patterns
+- pattern: contract-first slices de-risk large epics by landing CI-enforced schemas before runtime endpoints

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ bun type-check        # Run TypeScript compiler
 
 # Linting
 bun lint              # Run ESLint
+bun run lint:openapi  # Validate OpenAPI v1 contract
 
 # Building
 bun build             # Build for production
@@ -200,6 +201,11 @@ bun start             # Start production server
 bunx convex deploy    # Deploy to production
 bunx convex dashboard # Open Convex dashboard
 ```
+
+## API Contract Docs
+
+- [API conventions](docs/api/conventions.md)
+- [OpenAPI v1 scaffold](docs/api/openapi.v1.yaml)
 
 ## Testing the App
 

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -1,0 +1,106 @@
+# API v1 Conventions
+
+Canonical contract for Heartbeat API v1. All `/api/v1/*` routes follow this document.
+
+## Content Types
+
+- Success responses: `application/json`
+- Error responses: `application/problem+json`
+
+## Authentication
+
+- API routes require `Authorization: Bearer <api_key>` unless marked public.
+- Missing/invalid auth returns `401` Problem Details.
+- Valid key with missing scope returns `403` Problem Details.
+
+## Error Envelope (RFC 9457-compatible)
+
+Every non-2xx response returns:
+
+```json
+{
+  "type": "https://heartbeat.dev/problems/not-found",
+  "title": "Monitor not found",
+  "status": 404,
+  "detail": "No monitor exists for this id",
+  "instance": "/api/v1/monitors/mon_123",
+  "requestId": "req_01hv..."
+}
+```
+
+Required members:
+
+- `type`
+- `title`
+- `status`
+- `detail` (required unless intentionally omitted for security)
+- `instance`
+
+Extension members are allowed (for example `requestId`, `code`, `retryAfter`).
+
+## Timestamps and IDs
+
+- Timestamps: RFC 3339 / ISO 8601 UTC strings (`2026-03-03T18:22:10.123Z`)
+- Resource IDs: stable string IDs (`mon_...`, `inc_...`, `chk_...`, `key_...`)
+- Numeric durations are milliseconds unless field explicitly says seconds.
+
+## Cursor Pagination
+
+List endpoints return:
+
+```json
+{
+  "data": [],
+  "page": {
+    "limit": 50,
+    "nextCursor": "cur_abc123"
+  }
+}
+```
+
+Rules:
+
+- Request query: `limit` (default `50`, max `200`), optional `cursor`
+- `nextCursor = null` means terminal page
+- Invalid cursor returns `400` Problem Details
+- Cursor is opaque and must not be parsed by clients
+
+## Filtering and Sorting
+
+Common query conventions:
+
+- `projectSlug=<slug>`
+- `status=<up|degraded|down|investigating|resolved>`
+- `from=<rfc3339>` / `to=<rfc3339>`
+- `sort=<field>` and `order=<asc|desc>`
+
+Rules:
+
+- Unknown filter/sort field returns `400` Problem Details
+- If `from > to`, return `400`
+- If both `sort` and `order` omitted, route uses deterministic default sort
+
+## Idempotency (POST/PATCH)
+
+- Header: `Idempotency-Key`
+- Replay window: 24 hours
+- Key scope: method + route + authenticated principal
+
+Behavior:
+
+- First request with a key is processed and stored with response status/body hash.
+- Exact replay (same payload) within window returns original response (`Idempotent-Replayed: true`).
+- Same key with different payload returns `409` Problem Details (`type` = conflict/idempotency).
+- Expired keys are ignored and treated as new requests.
+
+Example conflict error:
+
+```json
+{
+  "type": "https://heartbeat.dev/problems/idempotency-conflict",
+  "title": "Idempotency key conflict",
+  "status": 409,
+  "detail": "The same idempotency key was already used with a different payload.",
+  "instance": "/api/v1/monitors"
+}
+```

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -33,7 +33,7 @@ Required members:
 - `type`
 - `title`
 - `status`
-- `detail` (required unless intentionally omitted for security)
+- `detail` (optional, omit intentionally for security-sensitive errors)
 - `instance`
 
 Extension members are allowed (for example `requestId`, `code`, `retryAfter`).
@@ -70,7 +70,8 @@ Rules:
 Common query conventions:
 
 - `projectSlug=<slug>`
-- `status=<up|degraded|down|investigating|resolved>`
+- Monitor routes: `status=<up|degraded|down>`
+- Incident routes: `status=<investigating|identified|resolved>`
 - `from=<rfc3339>` / `to=<rfc3339>`
 - `sort=<field>` and `order=<asc|desc>`
 

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -33,8 +33,11 @@ Required members:
 - `type`
 - `title`
 - `status`
-- `detail` (optional, omit intentionally for security-sensitive errors)
 - `instance`
+
+Optional members:
+
+- `detail` (omit intentionally for security-sensitive errors)
 
 Extension members are allowed (for example `requestId`, `code`, `retryAfter`).
 

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -437,6 +437,7 @@ components:
       properties:
         data:
           type: array
+          maxItems: 200
           items:
             $ref: "#/components/schemas/Monitor"
         page:
@@ -505,6 +506,7 @@ components:
       properties:
         data:
           type: array
+          maxItems: 200
           items:
             $ref: "#/components/schemas/Check"
         page:
@@ -538,6 +540,7 @@ components:
       properties:
         data:
           type: array
+          maxItems: 200
           items:
             $ref: "#/components/schemas/Incident"
         page:

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -363,7 +363,7 @@ components:
   schemas:
     ProblemDetails:
       type: object
-      required: [type, title, status, detail, instance]
+      required: [type, title, status, instance]
       properties:
         type:
           type: string
@@ -567,11 +567,9 @@ components:
           items:
             $ref: "#/components/schemas/ApiKeyScope"
         projectSlugs:
-          anyOf:
-            - type: "null"
-            - type: array
-              items:
-                type: string
+          type: [array, "null"]
+          items:
+            type: string
         expiresAt:
           type: [string, "null"]
           format: date-time
@@ -608,11 +606,9 @@ components:
           items:
             $ref: "#/components/schemas/ApiKeyScope"
         projectSlugs:
-          anyOf:
-            - type: "null"
-            - type: array
-              items:
-                type: string
+          type: [array, "null"]
+          items:
+            type: string
         expiresAt:
           type: [string, "null"]
           format: date-time

--- a/docs/api/openapi.v1.yaml
+++ b/docs/api/openapi.v1.yaml
@@ -1,0 +1,654 @@
+openapi: 3.1.0
+info:
+  title: Heartbeat API
+  version: 1.0.0
+  description: |
+    Agent-first API v1 contract. Runtime rollout may be staged; planned operations
+    are represented here for SDK generation and contract-first development.
+servers:
+  - url: https://heartbeat.dev
+    description: Production
+  - url: http://localhost:3000
+    description: Local development
+security:
+  - bearerApiKey: []
+tags:
+  - name: Me
+  - name: Monitors
+  - name: Checks
+  - name: Incidents
+  - name: API Keys
+paths:
+  /api/v1/me:
+    get:
+      operationId: getCurrentUserContext
+      summary: Get current API principal context
+      tags: [Me]
+      x-internal: planned
+      responses:
+        "200":
+          description: Current user context
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MeResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/monitors:
+    get:
+      operationId: listMonitorsV1
+      summary: List monitors
+      tags: [Monitors]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/CursorParam"
+        - $ref: "#/components/parameters/ProjectSlugParam"
+      responses:
+        "200":
+          description: Monitors page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitorsPageResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+    post:
+      operationId: createMonitorV1
+      summary: Create monitor
+      tags: [Monitors]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateMonitorRequest"
+      responses:
+        "201":
+          description: Monitor created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitorResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/monitors/{monitorId}:
+    parameters:
+      - $ref: "#/components/parameters/MonitorIdParam"
+    get:
+      operationId: getMonitorV1
+      summary: Get monitor by id
+      tags: [Monitors]
+      x-internal: planned
+      responses:
+        "200":
+          description: Monitor detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitorResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+    patch:
+      operationId: updateMonitorV1
+      summary: Update monitor by id
+      tags: [Monitors]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMonitorRequest"
+      responses:
+        "200":
+          description: Monitor updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitorResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+    delete:
+      operationId: deleteMonitorV1
+      summary: Delete monitor by id
+      tags: [Monitors]
+      x-internal: planned
+      responses:
+        "204":
+          description: Monitor deleted
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/monitors/{monitorId}/checks:
+    parameters:
+      - $ref: "#/components/parameters/MonitorIdParam"
+    get:
+      operationId: listMonitorChecksV1
+      summary: List checks for a monitor
+      tags: [Checks]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/CursorParam"
+        - $ref: "#/components/parameters/FromParam"
+        - $ref: "#/components/parameters/ToParam"
+      responses:
+        "200":
+          description: Checks page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChecksPageResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/monitors/{monitorId}/incidents:
+    parameters:
+      - $ref: "#/components/parameters/MonitorIdParam"
+    get:
+      operationId: listMonitorIncidentsV1
+      summary: List incidents for a monitor
+      tags: [Incidents]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/CursorParam"
+      responses:
+        "200":
+          description: Incidents page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IncidentsPageResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/incidents:
+    get:
+      operationId: listIncidentsV1
+      summary: List incidents across monitors
+      tags: [Incidents]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/CursorParam"
+        - $ref: "#/components/parameters/ProjectSlugParam"
+      responses:
+        "200":
+          description: Incidents page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IncidentsPageResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/projects/{slug}/incidents:
+    parameters:
+      - $ref: "#/components/parameters/ProjectSlugPathParam"
+    get:
+      operationId: listProjectIncidentsV1
+      summary: List incidents for a project
+      tags: [Incidents]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/CursorParam"
+      responses:
+        "200":
+          description: Project incidents page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IncidentsPageResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/api-keys:
+    get:
+      operationId: listApiKeysV1
+      summary: List API key metadata
+      tags: [API Keys]
+      x-internal: planned
+      responses:
+        "200":
+          description: API key list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiKeyListResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+    post:
+      operationId: createApiKeyV1
+      summary: Create API key
+      tags: [API Keys]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateApiKeyRequest"
+      responses:
+        "201":
+          description: API key created. Secret shown once.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateApiKeyResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/api-keys/{apiKeyId}/rotate:
+    parameters:
+      - $ref: "#/components/parameters/ApiKeyIdParam"
+    post:
+      operationId: rotateApiKeyV1
+      summary: Rotate API key secret
+      tags: [API Keys]
+      x-internal: planned
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
+      responses:
+        "200":
+          description: API key rotated. Secret shown once.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateApiKeyResponse"
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+  /api/v1/api-keys/{apiKeyId}:
+    parameters:
+      - $ref: "#/components/parameters/ApiKeyIdParam"
+    delete:
+      operationId: revokeApiKeyV1
+      summary: Revoke API key
+      tags: [API Keys]
+      x-internal: planned
+      responses:
+        "204":
+          description: API key revoked
+        default:
+          $ref: "#/components/responses/ProblemResponse"
+
+components:
+  securitySchemes:
+    bearerApiKey:
+      type: http
+      scheme: bearer
+      bearerFormat: hb_live
+      description: Heartbeat API key (`hb_live_<prefix>_<secret>`)
+
+  parameters:
+    LimitParam:
+      in: query
+      name: limit
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+    CursorParam:
+      in: query
+      name: cursor
+      schema:
+        type: string
+    ProjectSlugParam:
+      in: query
+      name: projectSlug
+      schema:
+        type: string
+    ProjectSlugPathParam:
+      in: path
+      name: slug
+      required: true
+      schema:
+        type: string
+    MonitorIdParam:
+      in: path
+      name: monitorId
+      required: true
+      schema:
+        type: string
+    ApiKeyIdParam:
+      in: path
+      name: apiKeyId
+      required: true
+      schema:
+        type: string
+    FromParam:
+      in: query
+      name: from
+      schema:
+        type: string
+        format: date-time
+    ToParam:
+      in: query
+      name: to
+      schema:
+        type: string
+        format: date-time
+    IdempotencyKeyHeader:
+      in: header
+      name: Idempotency-Key
+      required: false
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 255
+      description: |
+        Idempotency key for POST/PATCH write safety. Replays are honored for 24h.
+
+  responses:
+    ProblemResponse:
+      description: RFC 9457 problem details
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+
+  schemas:
+    ProblemDetails:
+      type: object
+      required: [type, title, status, detail, instance]
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+          minimum: 100
+          maximum: 599
+        detail:
+          type: string
+        instance:
+          type: string
+        requestId:
+          type: string
+      additionalProperties: true
+
+    PageInfo:
+      type: object
+      required: [limit, nextCursor]
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 200
+        nextCursor:
+          type: [string, "null"]
+
+    Monitor:
+      type: object
+      required: [id, name, url, intervalSeconds, status, projectSlug, createdAt]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        url:
+          type: string
+          format: uri
+        intervalSeconds:
+          type: integer
+          enum: [60, 120, 300, 600, 1800, 3600]
+        method:
+          type: string
+          enum: [GET, HEAD]
+        status:
+          type: string
+          enum: [up, degraded, down]
+        projectSlug:
+          type: string
+        lastCheckAt:
+          type: [string, "null"]
+          format: date-time
+        lastResponseTimeMs:
+          type: [integer, "null"]
+        createdAt:
+          type: string
+          format: date-time
+
+    MonitorResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          $ref: "#/components/schemas/Monitor"
+
+    MonitorsPageResponse:
+      type: object
+      required: [data, page]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Monitor"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+
+    CreateMonitorRequest:
+      type: object
+      required: [name, url, intervalSeconds]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        url:
+          type: string
+          format: uri
+        intervalSeconds:
+          type: integer
+          enum: [60, 120, 300, 600, 1800, 3600]
+        method:
+          type: string
+          enum: [GET, HEAD]
+          default: GET
+        projectSlug:
+          type: string
+
+    UpdateMonitorRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        intervalSeconds:
+          type: integer
+          enum: [60, 120, 300, 600, 1800, 3600]
+        method:
+          type: string
+          enum: [GET, HEAD]
+        enabled:
+          type: boolean
+      minProperties: 1
+
+    Check:
+      type: object
+      required: [id, status, responseTimeMs, checkedAt]
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+          enum: [up, degraded, down]
+        responseTimeMs:
+          type: integer
+        statusCode:
+          type: [integer, "null"]
+        error:
+          type: [string, "null"]
+        checkedAt:
+          type: string
+          format: date-time
+
+    ChecksPageResponse:
+      type: object
+      required: [data, page]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Check"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+
+    Incident:
+      type: object
+      required: [id, monitorId, startedAt, state]
+      properties:
+        id:
+          type: string
+        monitorId:
+          type: string
+        projectSlug:
+          type: string
+        state:
+          type: string
+          enum: [investigating, identified, resolved]
+        startedAt:
+          type: string
+          format: date-time
+        resolvedAt:
+          type: [string, "null"]
+          format: date-time
+        summary:
+          type: [string, "null"]
+
+    IncidentsPageResponse:
+      type: object
+      required: [data, page]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Incident"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+
+    ApiKeyScope:
+      type: string
+      enum:
+        - monitors:read
+        - monitors:write
+        - checks:read
+        - incidents:read
+        - api_keys:write
+
+    ApiKeyMetadata:
+      type: object
+      required: [id, name, prefix, scopes, createdAt]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        prefix:
+          type: string
+        scopes:
+          type: array
+          items:
+            $ref: "#/components/schemas/ApiKeyScope"
+        projectSlugs:
+          anyOf:
+            - type: "null"
+            - type: array
+              items:
+                type: string
+        expiresAt:
+          type: [string, "null"]
+          format: date-time
+        lastUsedAt:
+          type: [string, "null"]
+          format: date-time
+        revokedAt:
+          type: [string, "null"]
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+
+    ApiKeyListResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ApiKeyMetadata"
+
+    CreateApiKeyRequest:
+      type: object
+      required: [name, scopes]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        scopes:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/ApiKeyScope"
+        projectSlugs:
+          anyOf:
+            - type: "null"
+            - type: array
+              items:
+                type: string
+        expiresAt:
+          type: [string, "null"]
+          format: date-time
+
+    CreateApiKeyResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [apiKey, secret]
+          properties:
+            apiKey:
+              $ref: "#/components/schemas/ApiKeyMetadata"
+            secret:
+              type: string
+              description: One-time token reveal.
+
+    MeResponse:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [userId, tier, usage]
+          properties:
+            userId:
+              type: string
+            tier:
+              type: string
+              enum: [free, pulse, vital]
+            usage:
+              type: object
+              required: [monitorsUsed, monitorsLimit]
+              properties:
+                monitorsUsed:
+                  type: integer
+                monitorsLimit:
+                  type: integer

--- a/lib/api/__tests__/contracts.test.ts
+++ b/lib/api/__tests__/contracts.test.ts
@@ -7,6 +7,24 @@ import {
 } from "@/lib/api/contracts";
 
 describe("API contracts", () => {
+  it("builds RFC 9457 style problem details without extensions", () => {
+    const problem = buildProblemDetails({
+      type: "https://heartbeat.dev/problems/unauthorized",
+      title: "Unauthorized",
+      status: 401,
+      detail: "Invalid API key",
+      instance: "/api/v1/me",
+    });
+
+    expect(problem).toEqual({
+      type: "https://heartbeat.dev/problems/unauthorized",
+      title: "Unauthorized",
+      status: 401,
+      detail: "Invalid API key",
+      instance: "/api/v1/me",
+    });
+  });
+
   it("builds RFC 9457 style problem details with extensions", () => {
     const problem = buildProblemDetails({
       type: "https://heartbeat.dev/problems/not-found",
@@ -29,6 +47,23 @@ describe("API contracts", () => {
     });
   });
 
+  it("prevents extensions from overriding canonical problem fields", () => {
+    const problem = buildProblemDetails({
+      type: "https://heartbeat.dev/problems/conflict",
+      title: "Conflict",
+      status: 409,
+      detail: "Idempotency key conflict",
+      instance: "/api/v1/monitors",
+      extensions: {
+        title: "Wrong title",
+        status: 200,
+      },
+    });
+
+    expect(problem.title).toBe("Conflict");
+    expect(problem.status).toBe(409);
+  });
+
   it("builds paginated responses with deterministic metadata", () => {
     const response = buildPaginatedResponse(["a", "b"], "cursor_2", 2);
     expect(response).toEqual({
@@ -36,6 +71,17 @@ describe("API contracts", () => {
       page: {
         limit: 2,
         nextCursor: "cursor_2",
+      },
+    });
+  });
+
+  it("builds terminal paginated responses with null cursor and empty data", () => {
+    const response = buildPaginatedResponse<string>([], null, 50);
+    expect(response).toEqual({
+      data: [],
+      page: {
+        limit: 50,
+        nextCursor: null,
       },
     });
   });

--- a/lib/api/__tests__/contracts.test.ts
+++ b/lib/api/__tests__/contracts.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  API_IDEMPOTENCY_REPLAY_WINDOW_HOURS,
+  IDEMPOTENCY_KEY_HEADER,
+  buildPaginatedResponse,
+  buildProblemDetails,
+} from "@/lib/api/contracts";
+
+describe("API contracts", () => {
+  it("builds RFC 9457 style problem details with extensions", () => {
+    const problem = buildProblemDetails({
+      type: "https://heartbeat.dev/problems/not-found",
+      title: "Monitor not found",
+      status: 404,
+      detail: "No monitor exists for this id",
+      instance: "/api/v1/monitors/mon_123",
+      extensions: {
+        requestId: "req_123",
+      },
+    });
+
+    expect(problem).toEqual({
+      type: "https://heartbeat.dev/problems/not-found",
+      title: "Monitor not found",
+      status: 404,
+      detail: "No monitor exists for this id",
+      instance: "/api/v1/monitors/mon_123",
+      requestId: "req_123",
+    });
+  });
+
+  it("builds paginated responses with deterministic metadata", () => {
+    const response = buildPaginatedResponse(["a", "b"], "cursor_2", 2);
+    expect(response).toEqual({
+      data: ["a", "b"],
+      page: {
+        limit: 2,
+        nextCursor: "cursor_2",
+      },
+    });
+  });
+
+  it("publishes idempotency contract constants", () => {
+    expect(IDEMPOTENCY_KEY_HEADER).toBe("Idempotency-Key");
+    expect(API_IDEMPOTENCY_REPLAY_WINDOW_HOURS).toBe(24);
+  });
+});

--- a/lib/api/__tests__/contracts.test.ts
+++ b/lib/api/__tests__/contracts.test.ts
@@ -64,6 +64,18 @@ describe("API contracts", () => {
     expect(problem.status).toBe(409);
   });
 
+  it("rejects non-HTTP status values for problem details", () => {
+    expect(() =>
+      buildProblemDetails({
+        type: "https://heartbeat.dev/problems/internal",
+        title: "Internal error",
+        status: 700,
+        detail: "Unexpected condition",
+        instance: "/api/v1/monitors",
+      }),
+    ).toThrow("ProblemDetails status must be an integer between 100 and 599");
+  });
+
   it("builds paginated responses with deterministic metadata", () => {
     const response = buildPaginatedResponse(["a", "b"], "cursor_2", 2);
     expect(response).toEqual({

--- a/lib/api/__tests__/contracts.test.ts
+++ b/lib/api/__tests__/contracts.test.ts
@@ -98,6 +98,23 @@ describe("API contracts", () => {
     });
   });
 
+  it("rejects pagination limits outside documented contract bounds", () => {
+    expect(() => buildPaginatedResponse([], null, 0)).toThrow(
+      "Pagination limit must be an integer between 1 and 200",
+    );
+    expect(() => buildPaginatedResponse([], null, 201)).toThrow(
+      "Pagination limit must be an integer between 1 and 200",
+    );
+    expect(() => buildPaginatedResponse([], null, 1.5)).toThrow(
+      "Pagination limit must be an integer between 1 and 200",
+    );
+  });
+
+  it("accepts pagination limit boundary values", () => {
+    expect(buildPaginatedResponse([], null, 1).page.limit).toBe(1);
+    expect(buildPaginatedResponse([], null, 200).page.limit).toBe(200);
+  });
+
   it("publishes idempotency contract constants", () => {
     expect(IDEMPOTENCY_KEY_HEADER).toBe("Idempotency-Key");
     expect(API_IDEMPOTENCY_REPLAY_WINDOW_HOURS).toBe(24);

--- a/lib/api/contracts.ts
+++ b/lib/api/contracts.ts
@@ -33,8 +33,8 @@ export function buildProblemDetails(
 ): ProblemDetails {
   const { extensions, ...base } = input;
   return {
-    ...base,
     ...(extensions ?? {}),
+    ...base,
   };
 }
 

--- a/lib/api/contracts.ts
+++ b/lib/api/contracts.ts
@@ -53,6 +53,10 @@ export function buildPaginatedResponse<T>(
   nextCursor: string | null,
   limit: number,
 ): PaginatedResponse<T> {
+  if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+    throw new Error("Pagination limit must be an integer between 1 and 200");
+  }
+
   return {
     data,
     page: {

--- a/lib/api/contracts.ts
+++ b/lib/api/contracts.ts
@@ -31,6 +31,16 @@ export type PaginatedResponse<T> = {
 export function buildProblemDetails(
   input: ProblemDetailsInput,
 ): ProblemDetails {
+  if (
+    !Number.isInteger(input.status) ||
+    input.status < 100 ||
+    input.status > 599
+  ) {
+    throw new Error(
+      "ProblemDetails status must be an integer between 100 and 599",
+    );
+  }
+
   const { extensions, ...base } = input;
   return {
     ...(extensions ?? {}),

--- a/lib/api/contracts.ts
+++ b/lib/api/contracts.ts
@@ -6,7 +6,7 @@ export type ProblemDetails = {
   title: string;
   status: number;
   detail?: string;
-  instance?: string;
+  instance: string;
 } & Record<string, unknown>;
 
 export type ProblemDetailsInput = {
@@ -14,7 +14,7 @@ export type ProblemDetailsInput = {
   title: string;
   status: number;
   detail?: string;
-  instance?: string;
+  instance: string;
   extensions?: Record<string, unknown>;
 };
 

--- a/lib/api/contracts.ts
+++ b/lib/api/contracts.ts
@@ -1,0 +1,53 @@
+export const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+export const API_IDEMPOTENCY_REPLAY_WINDOW_HOURS = 24;
+
+export type ProblemDetails = {
+  type: string;
+  title: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+} & Record<string, unknown>;
+
+export type ProblemDetailsInput = {
+  type: string;
+  title: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+  extensions?: Record<string, unknown>;
+};
+
+export type CursorPagination = {
+  limit: number;
+  nextCursor: string | null;
+};
+
+export type PaginatedResponse<T> = {
+  data: T[];
+  page: CursorPagination;
+};
+
+export function buildProblemDetails(
+  input: ProblemDetailsInput,
+): ProblemDetails {
+  const { extensions, ...base } = input;
+  return {
+    ...base,
+    ...(extensions ?? {}),
+  };
+}
+
+export function buildPaginatedResponse<T>(
+  data: T[],
+  nextCursor: string | null,
+  limit: number,
+): PaginatedResponse<T> {
+  return {
+    data,
+    page: {
+      limit,
+      nextCursor,
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "bunx convex deploy --cmd 'next build'",
     "start": "next start",
     "lint": "eslint . --max-warnings 0",
+    "lint:openapi": "bunx @redocly/cli@2.11.1 lint docs/api/openapi.v1.yaml",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
Builds the Phase 0 API contract foundation for agent-first API v1: canonical conventions + OpenAPI 3.1 scaffold + CI lint gate.

References #128.
Closes #129.
Closes #130.

## Changes
- Added API-wide conventions doc with RFC 9457 problem details, cursor pagination, filter/sort rules, timestamp/ID formatting, and idempotency semantics.
- Added OpenAPI 3.1 scaffold covering all v1 planned endpoints from #128 with shared bearer auth, problem schema, pagination schema, and unique operationIds.
- Added reusable API contract helpers in `lib/api/contracts.ts` for problem details, pagination envelope, and idempotency constants.
- Added focused unit tests for the API contract helpers.
- Added `lint:openapi` script and wired OpenAPI lint into CI `test.yml`.
- Linked API docs from README.

## Acceptance Criteria
### #129 API conventions
- [x] Every API route in #128 can reference this spec without ambiguity.
- [x] Error schema includes `type`, `title`, `status`, `detail`, `instance`, and extension members.
- [x] Pagination conventions documented with examples and edge-case behavior.
- [x] Idempotency behavior documented for POST/PATCH including replay window and conflict handling.

### #130 OpenAPI scaffold + lint
- [x] OpenAPI document validates in CI (`bun run lint:openapi` + workflow step).
- [x] All v1 endpoints from #128 are represented (marked `x-internal: planned`).
- [x] Error responses use shared Problem Details schema component.
- [x] Security scheme for bearer API key is documented once and reused.

## Manual QA
1. `bun run lint:openapi`
   - Expected: spec validates (warnings allowed by current default ruleset).
2. `bun test lib/api/__tests__/contracts.test.ts`
   - Expected: 9 passing tests.
3. `bun lint`
   - Expected: ESLint passes with 0 warnings.
4. `bun type-check`
   - Expected: TypeScript check passes.
5. `git grep -n "operationId" docs/api/openapi.v1.yaml`
   - Expected: unique operation IDs for all declared paths.

## What Changed
```mermaid
graph TD
  A[#128 Agent-first API v1 Epic] --> B[#129 Conventions Contract]
  A --> C[#130 OpenAPI Scaffold]
  B --> D[docs/api/conventions.md]
  C --> E[docs/api/openapi.v1.yaml]
  C --> F[CI OpenAPI Lint Gate]
  B --> G[lib/api/contracts.ts]
  G --> H[lib/api/__tests__/contracts.test.ts]
```

## Before / After
- Before: no canonical API conventions doc, no machine-readable OpenAPI contract for v1 endpoints, no CI guardrail for API contract drift.
- After: conventions and OpenAPI v1 scaffold exist as source-of-truth artifacts, all planned v1 endpoints are modeled, and CI now validates the API contract.

## Test Coverage
- Added: `lib/api/__tests__/contracts.test.ts`
  - `buildProblemDetails`
  - `buildPaginatedResponse`
  - idempotency constants contract
- Verified project gates:
  - `bun lint`
  - `bun type-check`
  - pre-push Vitest suite (all passing)
- Gap intentionally left (out of scope): runtime API endpoint behavior tests (to be added with endpoint implementation issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API conventions for Heartbeat API v1 and a full OpenAPI v3.1 contract; README updated to reference API contract docs.
  * Added a retrospective note for Issue #128 describing scope and CI contract pattern.

* **Chores**
  * Added a CI OpenAPI lint step and a local lint command (lint:openapi).

* **Tests**
  * Added tests validating API contract helpers (problem details, pagination, idempotency constants).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Before / After (Polish Pass)
- Before: pagination constraints were documented but not fully enforced at helper and OpenAPI page-array boundaries; two minor bot review threads remained unresolved.
- After: pagination invariants are enforced in both code and schema (buildPaginatedResponse limit guard + maxItems: 200 on paginated response arrays), regression tests cover invalid/boundary limits, and all review threads are resolved.

